### PR TITLE
Use https for all openstreetmap.org URLs

### DIFF
--- a/update
+++ b/update
@@ -53,9 +53,9 @@ while (1) {
 	my $now = time();
 	my $did = 0;
 
-	open(IN, "curl -q -m 120 http://www.openstreetmap.org/traces/rss |");
+	open(IN, "curl -q -m 120 https://www.openstreetmap.org/traces/rss |");
 	while (<IN>) {
-		if (/<link>(http:\/\/www.openstreetmap.org\/user\/(.*)\/traces\/(.*))<\/link>/) {
+		if (/<link>(https:\/\/www.openstreetmap.org\/user\/(.*)\/traces\/(.*))<\/link>/) {
 			my $track = $3;
 
 			if ($track > $max) {
@@ -77,7 +77,7 @@ while (1) {
 		print "$i\n";
 		$min = $i;
 
-		open (IN, "curl -q -m 120 --compress http://www.openstreetmap.org/trace/$i/data |");
+		open (IN, "curl -q -m 120 --compress https://www.openstreetmap.org/trace/$i/data |");
 		open(OUT, ">tracks/pending/$i.gpx");
 		while (<IN>) {
 			print OUT;


### PR DESCRIPTION
Without this everything fails as curl doesn't follow the redirect from http to https by default.