### PR TITLE
Resolve ambiguous switch error with recent curl

### DIFF
--- a/update
+++ b/update
@@ -77,7 +77,7 @@ while (1) {
 		print "$i\n";
 		$min = $i;
 
-		open (IN, "curl -q -m 120 --compress http://www.openstreetmap.org/trace/$i/data |");
+		open (IN, "curl -q -m 120 --compressed http://www.openstreetmap.org/trace/$i/data |");
 		open(OUT, ">tracks/pending/$i.gpx");
 		while (<IN>) {
 			print OUT;


### PR DESCRIPTION
Without this every call errors:

```
Jun 26 13:38:13 noquiklos.openstreetmap.org update[7332]: curl: option --compress: is ambiguous
Jun 26 13:38:13 noquiklos.openstreetmap.org update[7332]: curl: try 'curl --help' or 'curl --manual' for more information
```